### PR TITLE
Add redirects for three articles

### DIFF
--- a/articles/design-challenge-avoid-centralization-and-singletons.html
+++ b/articles/design-challenge-avoid-centralization-and-singletons.html
@@ -1,0 +1,10 @@
+<!doctype html>
+  <html>
+  <head>
+    <title>[Redirecting...] Design Challenge: Avoiding Centralization and Singletons - Articles - SSBC</title>
+    <meta http-equiv="refresh" content="0;URL=https://handbook.scuttlebutt.nz/stories/design-challenge-avoid-centralization-and-singletons">
+  </head>
+  <body>
+    <p>Article moved: <a href="https://handbook.scuttlebutt.nz/stories/design-challenge-avoid-centralization-and-singletons">Design Challenge: Avoiding Centralization and Singletons - Articles - SSBC</a></p>
+  </body>
+  </html>

--- a/articles/design-challenge-sybil-attack.html
+++ b/articles/design-challenge-sybil-attack.html
@@ -1,0 +1,10 @@
+<!doctype html>
+  <html>
+  <head>
+    <title>[Redirecting...] Design Challenge: Sybil Attacks - Articles - SSBC</title>
+    <meta http-equiv="refresh" content="0;URL=https://handbook.scuttlebutt.nz/stories/design-challenge-sybil-attacks">
+  </head>
+  <body>
+    <p>Article moved: <a href="https://handbook.scuttlebutt.nz/stories/design-challenge-sybil-attacks">Design Challenge: Sybil Attacks - Articles - SSBC</a></p>
+  </body>
+  </html>

--- a/articles/using-trust-in-open-networks.html
+++ b/articles/using-trust-in-open-networks.html
@@ -1,0 +1,10 @@
+<!doctype html>
+  <html>
+  <head>
+    <title>[Redirecting...] Using Trust in Open Networks - Articles - SSBC</title>
+    <meta http-equiv="refresh" content="0;URL=https://handbook.scuttlebutt.nz/stories/using-trust-in-open-networks">
+  </head>
+  <body>
+    <p>Article moved: <a href="https://handbook.scuttlebutt.nz/stories/using-trust-in-open-networks">Using Trust in Open Networks - Articles - SSBC</a></p>
+  </body>
+  </html>


### PR DESCRIPTION
https://ssbc.github.io/docs/articles/design-challenge-avoid-centralization-and-singletons.html → https://handbook.scuttlebutt.nz/stories/design-challenge-avoid-centralization-and-singletons
https://ssbc.github.io/docs/articles/design-challenge-sybil-attack.html → https://handbook.scuttlebutt.nz/stories/design-challenge-sybil-attacks
https://ssbc.github.io/docs/articles/using-trust-in-open-networks.html → https://handbook.scuttlebutt.nz/stories/using-trust-in-open-networks

Links were removed in https://github.com/ssbc/ssbc-sitegen/pull/9 and source files were removed in https://github.com/ssbc/docs/pull/25. But links still exist on some pages not yet rebuilt with ssbc-sitegen, e.g. https://ssbc.github.io/muxrpcli/ - and continue to exist in historical/immutable messages, e.g. [%UxZRLa7nLTT0PSePZRyBbun+tG5+D7dNoMsdehA86UY=.sha256](https://viewer.scuttlebot.io/%25UxZRLa7nLTT0PSePZRyBbun%2BtG5%2BD7dNoMsdehA86UY%3D.sha256). This PR adds redirect pages (using ssbc-sitegen @ [e9051a6e83ed57bde001859db4a1794b33b15655](http://git.scuttlebot.io/%25DZlKKOLjsNucyWhWghC6UoXHdFNixKCuio1V%2FwXOZZQ%3D.sha256/commit/e9051a6e83ed57bde001859db4a1794b33b15655)) to maintain the old URLs.

Archive links showing the previously-existing pages:
https://web.archive.org/web/20190426130608/https://ssbc.github.io/docs/articles/design-challenge-sybil-attack.html
https://web.archive.org/web/20160529105631/https://ssbc.github.io/docs/articles/using-trust-in-open-networks.html
https://web.archive.org/web/20181126101442/https://ssbc.github.io/docs/articles/design-challenge-avoid-centralization-and-singletons.html